### PR TITLE
Issue #30: SaveAttachment sets the Filename to the Full Path of the File

### DIFF
--- a/APIClient.IntegrationTests/IntegrationTests.cs
+++ b/APIClient.IntegrationTests/IntegrationTests.cs
@@ -426,7 +426,7 @@ namespace VersionOne.SDK.APIClient.IntegrationTests
             newDefect.SetAttributeValue(nameAttribute, name);
             services.Save(newDefect);
 
-            services.SaveAttachment(file, newDefect, "Test Attachment on " + newDefect.Oid);
+            services.SaveAttachment(file, newDefect, "Test Attachment on " + newDefect.Oid, false);
 
             var query = new Query(newDefect.Oid.Momentless);
             query.Selection.Add(attachmentsAttribute);

--- a/APIClient/Services/IServices.cs
+++ b/APIClient/Services/IServices.cs
@@ -32,8 +32,9 @@ namespace VersionOne.SDK.APIClient
         /// <param name="filePath">Path and name of the attachment file.</param>
         /// <param name="asset">Asset to save the attachment to.</param>
         /// <param name="attachmentName">The name of the attachment.</param>
+        /// <param name="useAbsolutePathAsFileName">Option to use the Ansolute Path as the FileName. Defaults to true.</param>
         /// <returns>Oid</returns>
-        Oid SaveAttachment(string filePath, Asset asset, string attachmentName);
+        Oid SaveAttachment(string filePath, Asset asset, string attachmentName, bool useAbsolutePathAsFileName = true);
 
         /// <summary>
         /// Saves an embedded image to the specified asset.

--- a/APIClient/Services/Services.cs
+++ b/APIClient/Services/Services.cs
@@ -375,12 +375,15 @@ namespace VersionOne.SDK.APIClient
             return _v1Connector.StringSendData(data: query, contentType: "application/json");
         }
 
-        public Oid SaveAttachment(string filePath, Asset asset, string attachmentName)
+        public Oid SaveAttachment(string filePath, Asset asset, string attachmentName, bool useAbsolutePathAsFileName = true)
         {
             if (string.IsNullOrWhiteSpace(filePath))
                 throw new ArgumentNullException("filePath");
             if (!File.Exists(filePath))
                 throw new APIException(string.Format("File \"{0}\" does not exist.", filePath));
+
+            if (!useAbsolutePathAsFileName)
+                filePath = Path.GetFileName(filePath);
 
             var mimeType = MimeType.Resolve(filePath);
             IAssetType attachmentType = Meta.GetAssetType("Attachment");


### PR DESCRIPTION
See https://github.com/versionone/VersionOne.SDK.NET.APIClient/issues/30

Added an optional argument to the SaveAttachment method: useAbsolutePathAsFileName = true

When set to false, it will use the file name + extension. It defaults to true and uses the Absolute Path of the file passed in through the fileName argument. 